### PR TITLE
feat(core): add multiple key-value pairs simultaneously

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ git clone <your-repo>
 cd envctl
 
 # Install dependencies
-npm install
+pnpm install
 
 # Build the project
-npm run build
+pnpm run build
 
 # Link globally for local testing
-npm link
+pnpm link --global
 
 # Now you can use envctl globally
 envctl --help
@@ -104,9 +104,7 @@ source ~/.bashrc  # or ~/.zshrc
 envctl create dev
 
 # Add some environment variables
-envctl add dev DATABASE_URL=postgresql://localhost/mydb
-envctl add dev API_KEY=secret123
-envctl add dev NODE_ENV=development
+envctl add dev DATABASE_URL=postgresql://localhost/mydb API_KEY=secret123 NODE_ENV=development
 
 # Or add from a .env file
 envctl add dev -f .env
@@ -150,13 +148,23 @@ envctl create staging
 envctl create dev
 ```
 
-### `envctl add <profile> <KEY=VALUE>`
+### `envctl add <profile> <KEY=VALUE> [KEY=VALUE...]`
 
-Add or update an environment variable in a profile.
+Add or update environment variable(s) in a profile. You can add multiple variables at once.
 
 ```bash
+# Add a single variable
 envctl add dev DATABASE_URL=postgresql://localhost/mydb
-envctl add dev API_PORT=3000
+
+# Add multiple variables at once
+envctl add dev DATABASE_URL=postgresql://localhost/mydb API_PORT=3000 NODE_ENV=development
+
+# Mix and match - add as many as you need
+envctl add production DATABASE_URL=postgresql://prod-host/db API_KEY=prod-secret DEBUG=false
+
+# Duplicate keys are handled intelligently - last value wins
+envctl add dev DATABASE_URL=first_value DATABASE_URL=final_value API_KEY=secret
+# Result: DATABASE_URL=final_value, API_KEY=secret (with warning about duplicate)
 ```
 
 ### `envctl add <profile> -f <file>`
@@ -179,6 +187,23 @@ NODE_ENV=development
 # Empty lines are ignored
 DEBUG=true
 ```
+
+**Duplicate Key Handling:**
+
+When adding multiple variables, if you provide the same key more than once, envctl will use the last value and warn you about the duplication:
+
+```bash
+# This command has duplicate DATABASE_URL keys
+envctl add dev DATABASE_URL=first API_KEY=secret DATABASE_URL=final
+
+# Output:
+# ✓ Added 2 variables (DATABASE_URL, API_KEY) to profile 'dev'
+# ⚠ Duplicate keys detected: DATABASE_URL (used last value for each)
+
+# Result: DATABASE_URL=final, API_KEY=secret
+```
+
+This behavior ensures you always get predictable results while being informed about potential mistakes.
 
 ### `envctl remove <profile> <key>`
 
@@ -394,24 +419,29 @@ cd ../beta && npm start
 
 ## Development
 
+This project uses **pnpm** (version 10.0.0 or higher) as the package manager and requires **Node.js 18+**. Make sure you have both installed:
+
 ```bash
+# Install pnpm globally if you haven't already
+npm install -g pnpm@latest
+
 # Install dependencies
-npm install
+pnpm install
 
 # Run in development mode
-npm run dev
+pnpm run dev
 
 # Build
-npm run build
+pnpm run build
 
 # Run tests
-npm test
+pnpm test
 
 # Run smoke tests (comprehensive integration tests)
-npm run smoke-test
+pnpm run smoke-test
 
 # Test user installation experience (important for catching dependency issues)
-npm run test:user-install
+pnpm run test:user-install
 ```
 
 ### Smoke Testing
@@ -422,13 +452,13 @@ Quick smoke test commands:
 
 ```bash
 # Run full smoke test suite
-npm run smoke-test
+pnpm run smoke-test
 
 # Debug mode for interactive testing
-npm run smoke-test:debug
+pnpm run smoke-test:debug
 
 # Using Docker Compose
-npm run smoke-test:compose
+pnpm run smoke-test:compose
 ```
 
 ## Contributing

--- a/src/env-manager.ts
+++ b/src/env-manager.ts
@@ -25,6 +25,22 @@ export class EnvManager {
     }
   }
 
+  private getShellRcFile = (homeDir: string, shell: string): string => {
+    // Extract shell name from path (e.g., '/usr/bin/zsh' -> 'zsh')
+    const shellName = shell.split('/').pop() || ''
+
+    switch (shellName) {
+      case 'zsh':
+        return this.deps.path.join(homeDir, '.zshrc')
+      case 'bash':
+        return this.deps.path.join(homeDir, '.bashrc')
+      case 'fish':
+        return this.deps.path.join(homeDir, '.config', 'fish', 'config.fish')
+      default:
+        return this.deps.path.join(homeDir, '.bashrc')
+    }
+  }
+
   createProfile = async (name: string): Promise<void> => {
     const existing = await this.storage.loadProfile(name)
     if (existing) {
@@ -329,18 +345,7 @@ export class EnvManager {
   setupShellIntegration = async (): Promise<{ rcFile: string; integrationFile: string }> => {
     const homeDir = this.deps.os.homedir()
     const shell = process.env['SHELL'] || ''
-
-    let rcFile: string
-    if (shell.includes('zsh')) {
-      rcFile = this.deps.path.join(homeDir, '.zshrc')
-    } else if (shell.includes('bash')) {
-      rcFile = this.deps.path.join(homeDir, '.bashrc')
-    } else if (shell.includes('fish')) {
-      rcFile = this.deps.path.join(homeDir, '.config', 'fish', 'config.fish')
-    } else {
-      rcFile = this.deps.path.join(homeDir, '.bashrc')
-    }
-
+    const rcFile = this.getShellRcFile(homeDir, shell)
     const integrationFile = this.deps.path.join(homeDir, '.envctl-integration.sh')
     const scriptPath = this.deps.path.join(__dirname, '..', 'shell-integration.sh')
 
@@ -435,18 +440,7 @@ alias ecsw='envctl-switch'
   unsetupShellIntegration = async (): Promise<{ rcFile: string; integrationFile: string; removed: string[] }> => {
     const homeDir = this.deps.os.homedir()
     const shell = process.env['SHELL'] || ''
-
-    let rcFile: string
-    if (shell.includes('zsh')) {
-      rcFile = this.deps.path.join(homeDir, '.zshrc')
-    } else if (shell.includes('bash')) {
-      rcFile = this.deps.path.join(homeDir, '.bashrc')
-    } else if (shell.includes('fish')) {
-      rcFile = this.deps.path.join(homeDir, '.config', 'fish', 'config.fish')
-    } else {
-      rcFile = this.deps.path.join(homeDir, '.bashrc')
-    }
-
+    const rcFile = this.getShellRcFile(homeDir, shell)
     const integrationFile = this.deps.path.join(homeDir, '.envctl-integration.sh')
     const removed: string[] = []
 


### PR DESCRIPTION
# feat: add support for multiple key-value pairs in single command


## Overview

This PR enhances the `envctl add` command to support adding multiple environment variables in a single command.

## Changes

### CLI Interface
- Updated `add` command to accept multiple `KEY=VALUE` pairs
- Added duplicate key detection with warning messages
- Improved error handling and user feedback

**Before:**
```bash
envctl add dev DATABASE_URL=postgresql://localhost/mydb
envctl add dev API_KEY=secret123
envctl add dev NODE_ENV=development
```

**After:**
```bash
envctl add dev DATABASE_URL=postgresql://localhost/mydb API_KEY=secret123 NODE_ENV=development
```

### Duplicate Key Handling
When duplicate keys are provided, the last value is used and a warning is displayed:
```
✓ Added 2 variables (DATABASE_URL, API_KEY) to profile 'dev'
⚠ Duplicate keys detected: DATABASE_URL (used last value for each)
```

## Technical Implementation

- **`src/cli.ts`**: Modified argument parsing from `[keyvalue]` to `[keyvalue...]`
- **`src/env-manager.ts`**: Added `getShellRcFile` helper method for better shell detection
- **`src/env-manager.test.ts`**: Added 5 test cases covering multiple variable scenarios
- **`scripts/smoke-test.sh`**: Extended integration tests for new functionality

## Documentation
- Updated README with multiple key-value examples
- Changed installation instructions from npm to pnpm
- Added duplicate key behavior documentation

## Testing
- Unit tests for multiple variable addition
- Integration tests for edge cases and special characters
- Backwards compatibility verification

## Backwards Compatibility
All existing single key-value commands continue to work unchanged.