### PR TITLE
refactor(core): stateless generation shell behavior is only behavior

### DIFF
--- a/shell-integration.sh
+++ b/shell-integration.sh
@@ -5,54 +5,54 @@
 
 # Function to load a profile
 envctl-load() {
-    if [ -z "$1" ]; then
-        echo "Usage: envctl-load <profile>"
-        return 1
-    fi
-    
-    local commands
-    commands=$(envctl load --shell "$1" 2>/dev/null)
-    if [ $? -eq 0 ]; then
-        eval "$commands"
-        echo "✓ Loaded profile '$1'"
-    else
-        echo "✗ Failed to load profile '$1'"
-        envctl load --shell "$1"  # Show the error
-        return 1
-    fi
+  if [[ -z $1 ]]; then
+    echo "Usage: envctl-load <profile>"
+    return 1
+  fi
+
+  local commands
+  commands=$(envctl load "$1" 2>/dev/null)
+  if [[ $? -eq 0 ]]; then
+    eval "${commands}"
+    echo "✓ Loaded profile '$1'"
+  else
+    echo "✗ Failed to load profile '$1'"
+    envctl load "$1" # Show the error
+    return 1
+  fi
 }
 
 # Function to unload current profile
 envctl-unload() {
-    local commands
-    commands=$(envctl unload --shell 2>/dev/null)
-    if [ $? -eq 0 ]; then
-        eval "$commands"
-        echo "✓ Unloaded profile"
-    else
-        echo "✗ Failed to unload profile"
-        envctl unload --shell  # Show the error
-        return 1
-    fi
+  local commands
+  commands=$(envctl unload 2>/dev/null)
+  if [[ $? -eq 0 ]]; then
+    eval "${commands}"
+    echo "✓ Unloaded profile"
+  else
+    echo "✗ Failed to unload profile"
+    envctl unload # Show the error
+    return 1
+  fi
 }
 
 # Function to switch profiles
 envctl-switch() {
-    if [ -z "$1" ]; then
-        echo "Usage: envctl-switch <profile>"
-        return 1
-    fi
-    
-    local commands
-    commands=$(envctl switch --shell "$1" 2>/dev/null)
-    if [ $? -eq 0 ]; then
-        eval "$commands"
-        echo "✓ Switched to profile '$1'"
-    else
-        echo "✗ Failed to switch to profile '$1'"
-        envctl switch --shell "$1"  # Show the error
-        return 1
-    fi
+  if [[ -z $1 ]]; then
+    echo "Usage: envctl-switch <profile>"
+    return 1
+  fi
+
+  local commands
+  commands=$(envctl switch "$1" 2>/dev/null)
+  if [[ $? -eq 0 ]]; then
+    eval "${commands}"
+    echo "✓ Switched to profile '$1'"
+  else
+    echo "✗ Failed to switch to profile '$1'"
+    envctl switch "$1" # Show the error
+    return 1
+  fi
 }
 
 # Aliases for convenience
@@ -60,4 +60,4 @@ alias ecl='envctl-load'
 alias ecu='envctl-unload'
 alias ecsw='envctl-switch'
 alias ecs='envctl status'
-alias ecls='envctl list' 
+alias ecls='envctl list'

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,5 @@ export const getConfig = (): Config => {
   return {
     configDir,
     profilesDir: path.join(configDir, 'profiles'),
-    stateFile: path.join(configDir, 'state.json'),
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,12 +5,7 @@ export interface Profile {
   updatedAt: Date
 }
 
-export interface EnvState {
-  currentProfile?: string
-}
-
 export interface Config {
   profilesDir: string
-  stateFile: string
   configDir: string
 }


### PR DESCRIPTION
# Streamline envctl behavior: Remove dual modes and implement stateless design

## Summary

Removes the confusing dual-mode behavior where commands worked differently with/without `--shell` flags. All environment-affecting commands (`load`, `unload`, `switch`) now consistently output shell commands that users execute with `eval`.

## Changes Made

### Core Architecture
- **Removed dual modes**: Eliminated `--shell` flags from `load`, `unload`, and `switch` commands
- **Stateless design**: Replaced `state.json` with backup file-based state detection
- **Smart reload**: Loading the same profile again refreshes it instead of throwing an error

### Code Changes
- Removed `EnvState` interface and related state management methods
- Updated `EnvManager` methods to always return shell commands
- Modified CLI commands to remove `--shell` options
- Updated shell integration scripts to work with new behavior
- Added `getCurrentlyLoadedProfile()` method that reads from backup file markers

### File Structure Changes
- Profiles: `~/.envctl/profiles/*.json` (unchanged)
- State tracking: `~/.envctl/backup.env` with `# envctl-profile:name` markers (replaces `state.json`)
- Configuration: `~/.envctl/` directory (unchanged)

## Behavior Changes

### Before
```bash
envctl load dev                    # Useless (only affects CLI process)
envctl load --shell dev            # Actually works
eval "$(envctl load --shell dev)"  # Required for functionality
```

### After
```bash
envctl load dev                    # Always outputs shell commands
eval "$(envctl load dev)"          # Clean, predictable workflow
eval "$(envctl load dev)"          # Reload works (no error)
```

## Testing

- **Unit tests**: 80/80 passing
- **Smoke tests**: 64/64 passing  
- **Docker environments**: Node 18, 20, 22 all passing
- **Shell compatibility**: bash, zsh tested

## Breaking Change(s)

- Removed `--shell` flags (users must update scripts)
- Commands now output shell commands instead of directly modifying environment
- `state.json` file no longer used (automatic migration)

## Migration

Existing users need to:
1. Remove `--shell` flags from scripts
2. Old workflows continue working with shell integration functions (`envctl-load`, etc.)
3. No data migration required - profiles preserved